### PR TITLE
💬 Renamer 'union type' til 'custom type'

### DIFF
--- a/book/README.md
+++ b/book/README.md
@@ -10,7 +10,7 @@ The workshop will cover the following topics:
 -   Records
 -   Type Inference
 -   Type Signatures
--   Union Types
+-   Custom Types
 -   Type Aliases
 -   Pattern Matching
 -   Functions

--- a/book/memory/LEVEL2.md
+++ b/book/memory/LEVEL2.md
@@ -1,6 +1,6 @@
 ## Level 2 - Learning types
 
-> The goal of this level is to learn union types and type aliases, which we often use to represent state.
+> The goal of this level is to learn about custom types and type aliases, which we often use to represent state.
 
 From here on we'll move in small steps, writing small chunks of code that will be a part of our final game, while using more and more features from functional programming and Elm along the way. Ready, set, go!
 
@@ -80,7 +80,7 @@ Remember also that string concatenation is done with `++`.
 
 If you now substitute the `greet` call in `main` with `viewCard` called with the record you created earlier you should see a beautiful little kitten on you screen!
 
-### 2.3 Union Types: Representing card state
+### 2.3 Custom Types: Representing card state
 
 Memory requires us to flip a card and reveal its image when clicked. This means we need a way to represent card state, as a card can be in one of three potential states: `Open | Closed | Matched`.
 
@@ -93,9 +93,9 @@ Think about how we'd store this state in JS. Most likely, we'd reach for a strin
 }
 ```
 
-This is obviously not very safe. This doesn't constrain us to using only the three possible values, and there's nothing to avoid typing errors. Elm and other ML-languages have a great feature for this use case: _Union Types_.
+This is obviously not very safe. This doesn't constrain us to using only the three possible values, and there's nothing to avoid typing errors. Elm and other ML-languages have a great feature for this use case: Custom Types_.
 
-A union type is like a Java enumerable or C# enum - a union type is a value that may be one of a fixed set of values. Chess pieces, for example, can only be either white or black.
+A custom type is somewhat like a Java enumerable or C# enum - a custom type is a value that may be one of a fixed set of values. Chess pieces, for example, can only be either white or black.
 
 ```elm
 type PieceColor = White | Black
@@ -108,7 +108,7 @@ White : PieceColor
 Black : PieceColor
 ```
 
-Union types may also carry data. This means that the _constructor functions_ for such union type values aren't zero argument functions. Let's look at an example:
+Custom types may also carry data. This means that the _constructor functions_ for such custom type values aren't zero argument functions. Let's look at an example:
 
 ```elm
 type CustomerAge = Unknown | Known Int
@@ -119,7 +119,7 @@ type CustomerAge = Unknown | Known Int
 This can be used to represent a customer's age in a situation where we might not know the age.
 We see that the constructor function `Known` takes an `Int` argument and returns a `CustomerAge`.
 
-We can wrap _any_ type of _accompanying data_ within a union type value (like `Known`), and the type of the accompanying data doesn't have to be the same for all the value types within a union.
+We can wrap _any_ type of _accompanying data_ within a custom type value (like `Known`), and the type of the accompanying data doesn't have to be the same for all the value types within a union.
 
 This is incredibly useful, and we will now make our own!
 
@@ -127,7 +127,7 @@ This is incredibly useful, and we will now make our own!
 
 **Task**:
 
-1. Create a union type called `CardState` that can be either `Open`, `Closed` or `Matched` (_constructor functions_ are always capitalized).
+1. Create a custom type called `CardState` that can be either `Open`, `Closed` or `Matched` (_constructor functions_ are always capitalized).
 1. Enrich our previous `Card` record with a field called `state` that carries a `CardState` value.
    You will also have to update the signature of `viewCard`.
 
@@ -207,7 +207,7 @@ isAdult customerAge =
 ```
 
 Notice that we can even extract the value that was used when `Known : Int -> CustomerAge` was used!
-This is a powerful technique, and is almost always used whenever there's a union type around.
+This is a powerful technique, and is almost always used whenever there's a custom type around.
 
 In our case, it is handy for rendering different stuff based on the `CardState` of a card.
 

--- a/book/memory/LEVEL3.md
+++ b/book/memory/LEVEL3.md
@@ -25,7 +25,7 @@ Now that you're getting warm, we will be giving you fewer specific instructions 
 
 1. Create a type alias `Model` that has the following type: `{ cards : List Card }`
 1. Create a value `init : Model`
-1. Create the union type `Msg` with only one constructor: `CardClick Card`
+1. Create the custom type `Msg` with only one constructor: `CardClick Card`
 1. Create a function `view : Model -> Html a` that renders a `div` with our list of cards.
 
 ### 3.2 Stuff is happening!

--- a/book/memory/LEVEL4.md
+++ b/book/memory/LEVEL4.md
@@ -10,7 +10,7 @@ Our deck of cards is a list of `Card`s and we will be passing them around in our
 Therefore, instead of having to write `List Card` everywhere, we want to be able to write `Deck`.
 
 Also, in the game we will be matching pairs of cards with each other, and will need some way to distinguish between two cards with the same image.
-We will do this by saying that a card can be _either_ in group `A` or in group `B`. Use a union type to achieve this, and add it as a field in our `Card` type.
+We will do this by saying that a card can be _either_ in group `A` or in group `B`. Use a custom type to achieve this, and add it as a field in our `Card` type.
 With this we can check if two cards are of one pair by comparing their `id` and `group` fields!
 
 ---
@@ -18,7 +18,7 @@ With this we can check if two cards are of one pair by comparing their `id` and 
 **Task:**
 
 -   Create a type alias for our deck of cards.
--   Create a union type for representing the group of a card.
+-   Create a custom type for representing the group of a card.
 -   Add `group` as a field in our `Card` type
 
 ### 4.2 Housekeeping part two
@@ -46,7 +46,7 @@ Use this by importing `DeckGenerator` in `Main.elm` and using the `DeckGenerator
 > -   Filename: `Models/User.elm` -> module: `Models.User`
 >
 > You must also be explicit with what your module exposes to the public by listing them along with the module declaration.
-> For type aliases and functions you just list their names, but for custom types (union types) you have two choices:
+> For type aliases and functions you just list their names, but for custom types you have two choices:
 >
 > -   exposing _only the type_ (often called opaque types)
 > -   exposing both the type and its constructors.
@@ -98,7 +98,7 @@ It should have the signature `updateCardClick : Card -> GameState -> GameState`.
 
 **Task:**
 
--   Implement the three game states as a union type called `GameState`
+-   Implement the three game states as a custom type called `GameState`
 -   Implement the `updateCardClick : Card -> GameState -> GameState` function
 -   Update your `update` and `view` functions to accommodate for the new shape of our model
 -   Now take a minute and pat yourself on the back for making an awesome game in Elm!

--- a/book/memory/TEA.md
+++ b/book/memory/TEA.md
@@ -24,7 +24,7 @@ A function that takes the current application state as an argument and returns s
 ##### Update
 
 A function that takes a "message", the current application state and returns an updated application state.
-This message is modeled with a union type, so usually the `update` function consists of pattern matching on the message value.
+This message is modeled with a custom type, so usually the `update` function consists of pattern matching on the message value.
 
 Messages are events that happen in our application.
 These could be for example:
@@ -75,7 +75,7 @@ The important part is that it returns a `Program` , which is just what the Elm r
 > -   `Html Int` - messages from this HTML will be ints
 > -   `Html String` - messages from this HTML will be string
 >
-> In practice we will use `union types` for our messages as they are incredibly useful, but it is useful to realize that our messages could in principle be of _any_ type.
+> In practice we will use `custom types` for our messages as they are incredibly useful, but it is useful to realize that our messages could in principle be of _any_ type.
 >
 > In the end, this means that when you hook up your `view` and `update` functions using `Browser.sandbox`, the messages sent to `update` will be of the type contained in the HTML.
 


### PR DESCRIPTION
Siden det nå kalles `union types` og ikke `custom types` lenger så endres overalt der dette nevnes. 

@ewendel må kanskje bygge boka på nytt for at endringene kommer frem?